### PR TITLE
Avoid <br> in pronunciation

### DIFF
--- a/index.css
+++ b/index.css
@@ -58,9 +58,8 @@ output {
 }
 
 output h3, output p { display: inline; }
-output :lang(och-Latn-fonipa) { white-space: initial; }
-output :not(rt):lang(och-Latn-fonipa) br, .tooltip-item :lang(och-Latn-fonipa) br { display: none; }
 .hidden { display: none; }
+.nowrap { white-space: nowrap; }
 
 .entry-multiple { color: #708; }
 .entry-multiple.entry-unresolved { color: #00f; }

--- a/src/index.js
+++ b/src/index.js
@@ -75,7 +75,8 @@ function makeTooltip(pronunciation, ress) {
 
   const spanPronunciation = document.createElement('span');
   spanPronunciation.lang = 'och-Latn-fonipa';
-  spanPronunciation.innerText = pronunciation;
+  spanPronunciation.classList.add('nowrap');
+  spanPronunciation.appendChild(document.createTextNode(pronunciation));
   tooltipItem.appendChild(spanPronunciation);
   tooltipItem.appendChild(document.createTextNode(' '));
 
@@ -119,7 +120,7 @@ function makeSingleEntry(ch, pronunciationMap) {
 
   const rt = document.createElement('rt');
   rt.lang = 'och-Latn-fonipa';
-  rt.innerText = pronunciation;
+  rt.appendChild(document.createTextNode(pronunciation));
   ruby.appendChild(rt);
 
   const rpRight = document.createElement('rp');
@@ -165,7 +166,8 @@ function makeMultipleEntry(ch, pronunciationMap) {
   for (const [i, [pronunciation, ress]] of [...pronunciationMap].entries()) {
     const tooltip = makeTooltip(pronunciation, ress);
     tooltip.addEventListener('click', () => {
-      rt.innerText = pronunciation;
+      rt.innerHTML = '';
+      rt.appendChild(document.createTextNode(pronunciation));
 
       ruby.classList.remove('entry-unresolved');
 
@@ -176,7 +178,8 @@ function makeMultipleEntry(ch, pronunciationMap) {
     tooltipArray.push(tooltip);
 
     if (i === 0) { // Select the first item by default
-      rt.innerText = pronunciation;
+      rt.innerHTML = '';
+      rt.appendChild(document.createTextNode(pronunciation));
       tooltip.classList.add('selected');
     }
   }
@@ -245,7 +248,8 @@ function handleConvertPresetArticle() {
       const 音韻地位 = Qieyun.音韻地位.from描述(描述);
       const 擬音 = callDeriver(音韻地位, 漢字);
       rt.lang = 'och-Latn-fonipa';
-      rt.innerText = 擬音;
+      rt.innerText = '';
+      rt.appendChild(document.createTextNode(擬音));
     });
 
     // Change h1 to h3

--- a/src/index.js
+++ b/src/index.js
@@ -314,8 +314,6 @@ function handleExportAllSmallRhymes() {
 function handleExportAllSyllables() {
   const outputArea = document.getElementById('outputArea');
   outputArea.innerHTML = ''; // clear previous contents
-  const span = document.createElement('span');
-  span.lang = 'och-Latn-fonipa';
 
   const s = new Set();
   for (const 音韻地位 of Qieyun.iter音韻地位()) {
@@ -323,7 +321,9 @@ function handleExportAllSyllables() {
     s.add(res);
   }
 
-  span.innerText = [...s].join(', ');
+  const span = document.createElement('span');
+  span.lang = 'och-Latn-fonipa';
+  span.appendChild(document.createTextNode([...s].join(', ')));
   outputArea.appendChild(span);
 }
 


### PR DESCRIPTION
This PR is based on the following observation:

```javascript
> const span = document.createElement('span');
> span.innerText = 'a\nb';
> console.log(span.innerHTML);
a<br>b
```

```javascript
> const span = document.createElement('span');
> span.appendChild(document.createTextNode('a\nb'));
> console.log(span.innerHTML);
a
b
```

Therefore, this PR changes `innerText` to `createTextNode` for all pronunciations, so that we can avoid styling the `<br>` elements in CSS.